### PR TITLE
remove macroses from constants.inc generation

### DIFF
--- a/AnyEvent-YACurl/sync-constants.pl
+++ b/AnyEvent-YACurl/sync-constants.pl
@@ -24,6 +24,9 @@ for my $word (sort keys %{$words{FIRST}}) {
         | CURL_AT_LEAST_VERSION
         | CURL_ISOCPP
         | CURLWARNING
+        | CURL_IGNORE_DEPRECATION
+        | CURLOPTDEPRECATED
+        | CURL_DEPRECATED
     )\z/x;
 
     print $constants <<EOC;


### PR DESCRIPTION
building AnyEvent-YACurl-0.22 fails with:

```
cpanm -v --reinstall AnyEvent::YACurl 2>&1 | grep 'error:'
constants.inc:1088:52: error: ‘CURLOPTDEPRECATED’ undeclared (first use in this function); did you mean ‘CURLOPT_PRIVATE’?
constants.inc:2831:50: error: ‘CURL_DEPRECATED’ undeclared (first use in this function)
constants.inc:2948:58: error: ‘CURL_IGNORE_DEPRECATION’ undeclared (first use in this function)
```