### PR TITLE
remove CURL_HAS_DECLSPEC_ATTRIBUTE from constants generation

### DIFF
--- a/AnyEvent-YACurl/build.sh
+++ b/AnyEvent-YACurl/build.sh
@@ -1,6 +1,6 @@
 set -e
 
-CURLVER=8.1.2
+CURLVER=8.15.0
 [ -f curl-$CURLVER.tar.gz ] || curl --output curl-$CURLVER.tar.gz https://curl.se/download/curl-$CURLVER.tar.gz
 tar -xf curl-$CURLVER.tar.gz
 mv curl-$CURLVER curl-src

--- a/AnyEvent-YACurl/sync-constants.pl
+++ b/AnyEvent-YACurl/sync-constants.pl
@@ -27,6 +27,7 @@ for my $word (sort keys %{$words{FIRST}}) {
         | CURL_IGNORE_DEPRECATION
         | CURLOPTDEPRECATED
         | CURL_DEPRECATED
+        | CURL_HAS_DECLSPEC_ATTRIBUTE
     )\z/x;
 
     print $constants <<EOC;


### PR DESCRIPTION
Hi, @TvdW 

It turns out another non-constant macro was added to curl upstream last year:
https://github.com/curl/curl/blob/1fcf22585fa3d87a50c9dddc688d962978c0c120/docs/libcurl/symbols-in-versions#L48
https://github.com/curl/curl/blob/1fcf22585fa3d87a50c9dddc688d962978c0c120/include/curl/curl.h#L117

This patch resolves potential issues when building against the latest curl version.